### PR TITLE
Use milliseconds for JSON report

### DIFF
--- a/src/main/java/fr/jcgay/maven/profiler/ProfilerEventSpy.java
+++ b/src/main/java/fr/jcgay/maven/profiler/ProfilerEventSpy.java
@@ -291,12 +291,12 @@ public class ProfilerEventSpy extends AbstractEventSpy {
         for (Project project : context.getProjects()) {
             JsonObject projectObj = new JsonObject();
             projectObj.add("project", project.getName());
-            projectObj.add("time", project.getTime().toString());
+            projectObj.add("time", project.getMillisTimeStamp());
             JsonArray projectMojosArr = new JsonArray();
             for (EntryAndTime entry : project.getMojosWithTime()) {
                 JsonObject projectMojoObj = new JsonObject();
                 projectMojoObj.add("mojo", entry.getEntry().toString());
-                projectMojoObj.add("time", entry.getTime().toString());
+                projectMojoObj.add("time", entry.getMillisTimeStamp());
                 projectMojosArr.add(projectMojoObj);
             }
             projectObj.add("mojos", projectMojosArr);
@@ -309,7 +309,7 @@ public class ProfilerEventSpy extends AbstractEventSpy {
             for (EntryAndTime download : context.getDownloads()) {
                 JsonObject downloadObj = new JsonObject();
                 downloadObj.add("download", download.getEntry().toString());
-                downloadObj.add("time", download.getTime().toString());
+                downloadObj.add("time", download.getMillisTimeStamp());
                 downloadsArr.add(downloadObj);
             }
             obj.add("downloads", downloadsArr);

--- a/src/main/java/fr/jcgay/maven/profiler/template/EntryAndTime.java
+++ b/src/main/java/fr/jcgay/maven/profiler/template/EntryAndTime.java
@@ -19,4 +19,8 @@ public class EntryAndTime<T> {
     public Stopwatch getTime() {
         return time;
     }
+
+    public String getMillisTimeStamp() {
+        return String.valueOf(time.elapsedMillis()) + " ms";
+    }
 }

--- a/src/main/java/fr/jcgay/maven/profiler/template/Project.java
+++ b/src/main/java/fr/jcgay/maven/profiler/template/Project.java
@@ -32,4 +32,8 @@ public class Project {
     public Stopwatch getTime() {
         return time;
     }
+
+    public String getMillisTimeStamp() {
+        return String.valueOf(time.elapsedMillis()) + " ms";
+    }
 }


### PR DESCRIPTION
For the JSON report milliseconds are used. Having only one unit (ms)
makes it easier to reuse the timing results.

See: https://github.com/jcgay/maven-profiler/issues/4