### PR TITLE
Added a feature, a flag that enables the profiler to report times in order of execution instead of sorted by time spent on execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+.settings
+bin/
+.project
+.classpath
+mvnvm.properties
 target
 *.iml
 .idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+pom.xml.releaseBackup
 .settings
 bin/
 .project
@@ -8,4 +9,5 @@ target
 .idea
 .java-version
 .profiler
+release.properties
 .mvn/timing.properties

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ A time execution recorder for Maven which log time taken by each mojo in your bu
 ├── boot
 ├── conf
 └── lib
-``` 
+```
 
 ### OS X ?
 
-You can install a pre-packaged maven named [maven-deluxe](https://github.com/jcgay/homebrew-jcgay#maven-deluxe) using `brew`.  
-It comes with [maven-color](https://github.com/jcgay/maven-color), [maven-notifier](https://github.com/jcgay/maven-notifier) and [maven-profiler](https://github.com/jcgay/maven-profiler).  
+You can install a pre-packaged maven named [maven-deluxe](https://github.com/jcgay/homebrew-jcgay#maven-deluxe) using `brew`.
+It comes with [maven-color](https://github.com/jcgay/maven-color), [maven-notifier](https://github.com/jcgay/maven-notifier) and [maven-profiler](https://github.com/jcgay/maven-profiler).
 It is based on latest maven release.
 
     brew tap jcgay/jcgay
@@ -45,7 +45,7 @@ Use the new [core extensions configuration mechanism](http://takari.io/2015/03/1
 Get [maven-profiler](http://dl.bintray.com/jcgay/maven/fr/jcgay/maven/maven-profiler/2.3/maven-profiler-2.3-shaded.jar) and copy it in `%M2_HOME%/lib/ext` folder.
 
 ### Maven 3.0.x
-(with limited functionality, kept for compatibility)  
+(with limited functionality, kept for compatibility)
 Get [maven-profiler](http://dl.bintray.com/jcgay/maven/com/github/jcgay/maven/maven-profiler/1.0/maven-profiler-1.0.jar) and copy it in `%M2_HOME%/lib/ext` folder.
 
 ##Usage
@@ -53,10 +53,16 @@ Get [maven-profiler](http://dl.bintray.com/jcgay/maven/com/github/jcgay/maven/ma
 Use property `profile` when running Maven.
 
 	mvn install -Dprofile
-	
+
 This will generate a report in `.profiler` folder.
 
 One can choose between `HTML` (by default) or `JSON` report using property `profileFormat`.
+
+Also you can add the property `disableTimeSorting` if you want the reported times to be in the order of execution
+instead of sorted by execution time.
+
+    mvn install -Dprofile -DdisableTimeSorting
+
 
 ### HTML
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>fr.jcgay.maven</groupId>
     <artifactId>maven-profiler</artifactId>
-    <version>2.5-SNAPSHOT</version>
+    <version>2.5</version>
 
     <prerequisites>
         <maven>3.0</maven>
@@ -20,7 +20,7 @@
         <url>https://github.com/jcgay/maven-profiler.git</url>
         <connection>scm:git:git://github.com/jcgay/maven-profiler.git</connection>
         <developerConnection>scm:git:git@github.com:jcgay/maven-profiler.git</developerConnection>
-      <tag>HEAD</tag>
+      <tag>v2.5</tag>
   </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>fr.jcgay.maven</groupId>
     <artifactId>maven-profiler</artifactId>
-    <version>2.4-SNAPSHOT</version>
+    <version>2.5-SNAPSHOT</version>
 
     <prerequisites>
         <maven>3.0</maven>

--- a/src/main/java/fr/jcgay/maven/profiler/ProfilerEventSpy.java
+++ b/src/main/java/fr/jcgay/maven/profiler/ProfilerEventSpy.java
@@ -362,7 +362,15 @@ public class ProfilerEventSpy extends AbstractEventSpy {
         timers.get(currentProject, currentEvent.getMojoExecution()).stop();
 
         if (!isSortingActive) {
-            sequenceEvents.add(new SequenceEvent(currentProject, currentEvent.getMojoExecution()));
+            SequenceEvent event = new SequenceEvent(currentProject, currentEvent.getMojoExecution());
+            if (!sequenceEvents.isEmpty()) {
+                SequenceEvent previousEvent = sequenceEvents.get(sequenceEvents.size() - 1);
+                if (!previousEvent.equals(event)) {
+                    sequenceEvents.add(event);
+                }
+            } else {
+                sequenceEvents.add(event);
+            }
         }
     }
 

--- a/src/main/java/fr/jcgay/maven/profiler/ProfilerEventSpy.java
+++ b/src/main/java/fr/jcgay/maven/profiler/ProfilerEventSpy.java
@@ -75,35 +75,6 @@ public class ProfilerEventSpy extends AbstractEventSpy {
         public void setProject(MavenProject project) {
             this.project = project;
         }
-
-        private static boolean equalString(String str1, String str2) {
-            return str1 != null && str2 != null && str1.equals(str2);
-        }
-
-        public boolean isDuplicated(SequenceEvent event) {
-            boolean isSameProject = false;
-            boolean isSameMojo = false;
-
-
-            MavenProject eventProject = event.getProject();
-            isSameProject = equalString(eventProject.getArtifactId(), project.getArtifactId()) &&
-                equalString(eventProject.getGroupId(), project.getGroupId()) &&
-                equalString(eventProject.getVersion(), project.getVersion()) &&
-                equalString(eventProject.getName(), project.getName()) &&
-                equalString(eventProject.getDefaultGoal(), project.getDefaultGoal()) &&
-                equalString(eventProject.getDescription(), project.getDescription());
-
-            MojoExecution eventMojo = event.getMojo();
-
-            isSameMojo = equalString(eventMojo.getArtifactId(), mojo.getArtifactId()) &&
-                equalString(eventMojo.getVersion(), mojo.getVersion()) &&
-                equalString(eventMojo.getExecutionId(), mojo.getExecutionId()) &&
-                equalString(eventMojo.getGroupId(), mojo.getGroupId()) &&
-                equalString(eventMojo.getGoal(), mojo.getGoal()) &&
-                equalString(eventMojo.getPlugin().toString(), mojo.getPlugin().toString());
-
-            return isSameProject && isSameMojo;
-        }
     }
 
     private List<SequenceEvent> sequenceEvents;
@@ -208,7 +179,6 @@ public class ProfilerEventSpy extends AbstractEventSpy {
     }
 
     private void writeReport() {
-
         Date now = new Date();
 
         Data context = new Data()
@@ -333,11 +303,13 @@ public class ProfilerEventSpy extends AbstractEventSpy {
 
     private void saveDownloadingTime(RepositoryEvent event) {
         logger.debug(String.format("Received event (%s): %s", event.getClass(), event));
-        if (event.getType() == RepositoryEvent.EventType.ARTIFACT_DOWNLOADING) {
-            startDownload(event);
-        }
-        if (event.getType() == RepositoryEvent.EventType.ARTIFACT_DOWNLOADED) {
-            stopDownload(event);
+        switch (event.getType()) {
+            case ARTIFACT_DOWNLOADING:
+                startDownload(event);
+                break;
+            case ARTIFACT_DOWNLOADED:
+                stopDownload(event);
+                break;
         }
     }
 
@@ -369,13 +341,13 @@ public class ProfilerEventSpy extends AbstractEventSpy {
         MavenProject currentProject = event.getSession().getCurrentProject();
         if (type == ExecutionEvent.Type.ProjectStarted) {
             startProject(currentProject);
-        }
+        } else
         if (type == ExecutionEvent.Type.ProjectSucceeded || type == ExecutionEvent.Type.ProjectFailed) {
             stopProject(currentProject);
-        }
+        } else
         if (type == ExecutionEvent.Type.MojoStarted) {
             startMojo(event, currentProject);
-        }
+        } else
         if (type == ExecutionEvent.Type.MojoSucceeded || type == ExecutionEvent.Type.MojoFailed) {
             stopMojo(event, currentProject);
         }

--- a/src/main/java/fr/jcgay/maven/profiler/template/Project.java
+++ b/src/main/java/fr/jcgay/maven/profiler/template/Project.java
@@ -36,4 +36,33 @@ public class Project {
     public String getMillisTimeStamp() {
         return String.valueOf(time.elapsedMillis()) + " ms";
     }
+
+    @Override
+    public String toString() {
+        return String.format("{%s, %s, totalMojos = %d}", name, getMillisTimeStamp(), mojosWithTime.size());
+    }
+
+    public boolean isEqual(Project project) {
+        if (name.equals(project.getName())) {
+            if (time.equals(project.getTime())) {
+                if (mojosWithTime.size() == project.getMojosWithTime().size()) {
+                    int index = 0;
+                    boolean hasSameMojos = true;
+                    for (EntryAndTime<MojoExecution> entryAndTime : mojosWithTime) {
+                        EntryAndTime<MojoExecution> entryAndTime2 = project.getMojosWithTime().get(index);
+
+                        if (!entryAndTime.getEntry().equals(entryAndTime2.getEntry()) ||
+                            !entryAndTime.getTime().equals(entryAndTime2.getTime())) {
+                            hasSameMojos = false;
+                            break;
+                        }
+                        index++;
+                    }
+                    return hasSameMojos;
+                }
+            }
+        }
+
+        return false;
+    }
 }

--- a/src/test/groovy/fr/jcgay/maven/profiler/ProfilerEventSpyTest.groovy
+++ b/src/test/groovy/fr/jcgay/maven/profiler/ProfilerEventSpyTest.groovy
@@ -61,13 +61,6 @@ class ProfilerEventSpyTest {
     }
 
     @Test
-    void 'should not create the sequence data structures'() throws Exception {
-        assertThat(profiler.getSequenceDownloads()).isNull();
-        assertThat(profiler.getSequenceEvents()).isNull();
-    }
-
-
-    @Test
     void 'should start a timer when a mojo start'() throws Exception {
         ExecutionEvent event = aMojoEvent(MojoStarted, aMavenProject('a-project'))
 

--- a/src/test/groovy/fr/jcgay/maven/profiler/ProfilerEventSpyTest.groovy
+++ b/src/test/groovy/fr/jcgay/maven/profiler/ProfilerEventSpyTest.groovy
@@ -50,6 +50,7 @@ class ProfilerEventSpyTest {
 
         System.setProperty('profile', 'true')
         System.clearProperty('profileFormat')
+        System.setProperty('disableTimeSorting', 'false')
 
         profiler = new ProfilerEventSpy(
                 projects,
@@ -58,6 +59,13 @@ class ProfilerEventSpyTest {
                 topProject
         )
     }
+
+    @Test
+    void 'should not create the sequence data structures'() throws Exception {
+        assertThat(profiler.getSequenceDownloads()).isNull();
+        assertThat(profiler.getSequenceEvents()).isNull();
+    }
+
 
     @Test
     void 'should start a timer when a mojo start'() throws Exception {

--- a/src/test/groovy/fr/jcgay/maven/profiler/ProjectEqualityTest.groovy
+++ b/src/test/groovy/fr/jcgay/maven/profiler/ProjectEqualityTest.groovy
@@ -1,0 +1,78 @@
+package fr.jcgay.maven.profiler
+
+import com.google.common.base.Stopwatch
+import fr.jcgay.maven.profiler.template.EntryAndTime
+import org.apache.maven.model.Plugin
+import org.apache.maven.plugin.MojoExecution
+import org.testng.annotations.Test
+
+import fr.jcgay.maven.profiler.template.Project
+
+import java.util.concurrent.TimeUnit
+
+import static org.assertj.core.api.Assertions.assertThat
+
+class ProjectEqualityTest {
+
+    @Test
+    void 'should compare two different instance of the same project'() throws Exception {
+        Stopwatch stopwatch = new Stopwatch();
+
+        Project project1 = new Project('test-project', stopwatch)
+        Project project2 = new Project('test-project', stopwatch)
+
+        assertThat(project1).is(project2)
+    }
+
+    @Test
+    void 'should compare two different instance of the same project with same mojos'() throws Exception {
+        Stopwatch stopwatch = aStopwatch();
+
+        Project project1 = new Project('test-project', stopwatch)
+        Project project2 = new Project('test-project', stopwatch)
+
+        MojoExecution testMojo = new MojoExecution(new Plugin(), 'test-goal', 'test-id')
+        EntryAndTime<MojoExecution> entryAndTime = new EntryAndTime<>(testMojo, aStopwatch());
+
+        project1.addMojoTime(entryAndTime);
+        project2.addMojoTime(entryAndTime);
+
+        assertThat(project1).is(project2)
+    }
+
+    @Test
+    void 'should report that projects are different because they have different mojos'() throws Exception {
+        Stopwatch stopwatch = aStopwatch();
+
+        Project project1 = new Project('test-project', stopwatch)
+        Project project2 = new Project('test-project', stopwatch)
+
+        EntryAndTime<MojoExecution> entryAndTime = aEntryAndTime('test-id')
+        project1.addMojoTime(entryAndTime);
+
+        assertThat(project1).isNotSameAs(project2)
+    }
+
+    @Test
+    void 'should report that project string is "{test-project, 0 ms, totalMojos = 3}"'() throws Exception {
+        Stopwatch stopwatch = new Stopwatch()
+        Project project = new Project('test-project', stopwatch)
+        project.addMojoTime(aEntryAndTime('test-entry-1'))
+        project.addMojoTime(aEntryAndTime('test-entry-2'))
+        project.addMojoTime(aEntryAndTime('test-entry-3'))
+        assertThat(project.toString()).isEqualTo("{test-project, 0 ms, totalMojos = 3}")
+    }
+
+    private static EntryAndTime<MojoExecution> aEntryAndTime(testId) {
+        MojoExecution testMojo = new MojoExecution(new Plugin(), 'test-goal', testId)
+        new EntryAndTime<MojoExecution>(testMojo, aStopwatch());
+    }
+
+    private static Stopwatch aStopwatch() {
+        Stopwatch stopwatch = new Stopwatch()
+        stopwatch.start()
+        TimeUnit.MILLISECONDS.sleep(10)
+        stopwatch.stop()
+        stopwatch
+    }
+}

--- a/src/test/groovy/fr/jcgay/maven/profiler/ReportsWithSortingDisabledTest.groovy
+++ b/src/test/groovy/fr/jcgay/maven/profiler/ReportsWithSortingDisabledTest.groovy
@@ -1,0 +1,246 @@
+package fr.jcgay.maven.profiler
+import com.google.common.base.Stopwatch
+import com.google.common.collect.HashBasedTable
+import com.google.common.collect.Table
+import org.apache.maven.execution.DefaultMavenExecutionRequest
+import org.apache.maven.execution.ExecutionEvent
+import org.apache.maven.model.Model
+import org.apache.maven.model.Plugin
+import org.apache.maven.plugin.MojoExecution
+import org.apache.maven.project.MavenProject
+import org.assertj.guava.api.Assertions
+import org.eclipse.aether.DefaultRepositorySystemSession
+import org.eclipse.aether.RepositoryEvent
+import org.eclipse.aether.artifact.Artifact
+import org.eclipse.aether.artifact.DefaultArtifact
+import org.eclipse.aether.repository.RemoteRepository
+import org.eclipse.aether.transfer.ArtifactNotFoundException
+import org.testng.Reporter
+import org.testng.ReporterConfig
+import org.testng.annotations.BeforeClass
+import org.testng.annotations.BeforeMethod
+import org.testng.annotations.DataProvider
+import org.testng.annotations.Test
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentMap
+
+import static fr.jcgay.maven.profiler.ProfilerEventSpy.PROFILE
+import static java.util.Arrays.asList
+import static java.util.concurrent.TimeUnit.MILLISECONDS
+import static org.apache.maven.execution.ExecutionEvent.Type.*
+import static org.assertj.core.api.Assertions.assertThat
+import static org.eclipse.aether.RepositoryEvent.EventType.ARTIFACT_DOWNLOADED
+import static org.eclipse.aether.RepositoryEvent.EventType.ARTIFACT_DOWNLOADING
+
+class ReportsWithSortingDisabledTest {
+
+    private static Random random
+
+    private ProfilerEventSpy profiler
+    private Table<MavenProject, MojoExecution, Stopwatch> timers
+    private ConcurrentMap<Artifact, Stopwatch> downloadTimers
+    private ConcurrentHashMap<MavenProject, Stopwatch> projects
+    private MavenProject topProject
+    private List<ProfilerEventSpy.SequenceEvent> sequenceEvents
+    private List<Artifact> sequenceDownloads
+
+    static {
+        random = new Random()
+    }
+
+    @BeforeMethod
+    void setUp() throws Exception {
+        timers = HashBasedTable.create()
+        downloadTimers = new ConcurrentHashMap<Artifact, Stopwatch>()
+
+        projects = new ConcurrentHashMap<MavenProject, Stopwatch>()
+
+        topProject = aMavenProject('top-project')
+        topProject.file = File.createTempFile('pom', '.xml')
+
+        System.setProperty('profile', 'true')
+        System.clearProperty('profileFormat')
+        System.setProperty('disableTimeSorting', 'true')
+
+        sequenceEvents = new LinkedList<>()
+        sequenceDownloads = new LinkedList<>()
+
+        profiler = new ProfilerEventSpy(
+                projects,
+                timers,
+                downloadTimers,
+                topProject,
+                sequenceEvents,
+                sequenceDownloads
+        )
+    }
+
+    @Test
+    void 'should report mojos in order of execution'() throws Exception {
+        MavenProject project = aMavenProject('test-project')
+
+        def mojos = [new Tuple('compile', 'maven-compile'),
+                     new Tuple('test', 'maven-test'),
+                     new Tuple('package', 'maven-package'),
+                     new Tuple('install', 'maven-install')] as Tuple[]
+
+        simulateProjectStartedExecution(profiler, project)
+
+        mojos.each {
+            simulateMojoExecutedSuccessfully(profiler, project, it.get(0), it.get(1))
+        }
+
+        simulateProjectEndedExecution(profiler, project)
+        profiler.close()
+
+        sequenceEvents.eachWithIndex {event, index ->
+            assertThat(event.mojo.goal).isEqualTo(mojos[index].get(0))
+            assertThat(event.mojo.executionId).isEqualTo(mojos[index].get(1))
+        }
+    }
+
+    @Test
+    void 'should report projects in order of execution'() throws Exception {
+        List<MavenProject> projects = new LinkedList<>();
+        def NUM_PROJECTS = 20 + (random.nextInt() % 10)
+        0.upto(NUM_PROJECTS, { projects.add(aMavenProject("test-project-${it}")) })
+
+        projects.each {
+            simulateProjectStartedExecution(profiler, it)
+            simulateMojoExecutedSuccessfully(profiler, it, 'test', it.name + '-testing-mojo')
+            simulateProjectEndedExecution(profiler, it)
+        }
+
+        profiler.close()
+
+        sequenceEvents.eachWithIndex {event, index ->
+            assertThat(event.project.model.name).isEqualTo(projects[index].model.name)
+        }
+    }
+
+    @Test
+    void 'should report both projects and mojos in order of execution'() throws Exception {
+        List<MavenProject> projects = new LinkedList<>();
+
+        def NUM_PROJECTS = 5
+        0.upto(NUM_PROJECTS, { projects.add(aMavenProject("test-project-${it}")) })
+
+        def NUM_MOJOS = 5
+        projects.each { project ->
+            simulateProjectStartedExecution(profiler, project)
+
+            0.upto(NUM_MOJOS, {
+                simulateMojoExecutedSuccessfully(profiler, project, "test-${it}", "testing-mojo-${it}")
+            })
+
+            simulateProjectEndedExecution(profiler, project)
+        }
+
+        profiler.close()
+
+        def eventIndex = 0
+        for (def projectIndex = 0; projectIndex < NUM_PROJECTS; projectIndex++) {
+            def event = sequenceEvents.get(eventIndex)
+            eventIndex++
+            assertThat(event.project.model.name).isEqualTo(projects.get(projectIndex).model.name)
+
+            for (def mojoIndex = 0; mojoIndex < NUM_MOJOS; mojoIndex++) {
+                assertThat(event.mojo.executionId).isEqualTo('testing-mojo-' + mojoIndex.toString())
+
+                event = sequenceEvents.get(eventIndex)
+                eventIndex++
+            }
+        }
+    }
+
+    @Test
+    private 'should report artifacts by order of download'() throws Exception {
+
+    }
+
+    private static Artifact anArtifact() {
+        ArtifactProfiled.of(new DefaultArtifact('groupId', 'artifactId', 'jar', '1.0'))
+    }
+
+    private void given_artifact_is_being_downloaded(Artifact artifact) throws Exception {
+        profiler.onEvent(aRepositoryEvent(ARTIFACT_DOWNLOADING, artifact).build())
+        MILLISECONDS.sleep(1)
+    }
+
+    private static RepositoryEvent.Builder aRepositoryEvent(RepositoryEvent.EventType type, Artifact artifact) {
+        new RepositoryEvent.Builder(new DefaultRepositorySystemSession(), type)
+                .setArtifact(artifact)
+    }
+
+    private static MavenProject aMavenProject(String name) {
+        Model model = new Model()
+        model.name = name
+        MavenProject project = new MavenProject(model)
+        project.groupId = 'groupId'
+        project.artifactId = 'artifactId'
+        project.version = '1.0'
+        project
+    }
+
+    private static void simulateArtifactDownloaded(ProfilerEventSpy profiler, Artifact artifact) {
+    }
+
+    private static void simulateProjectStartedExecution(ProfilerEventSpy profiler, MavenProject mavenProject) {
+        String projectGoal = mavenProject.getDefaultGoal()
+        String projectId = mavenProject.getId()
+        ExecutionEvent projectStartEvent = aMojoEvent(ExecutionEvent.Type.ProjectStarted,
+                                                      projectGoal, projectId,
+                                                      mavenProject)
+        profiler.onEvent(projectStartEvent)
+    }
+
+    private static void simulateProjectEndedExecution(ProfilerEventSpy profiler, MavenProject mavenProject) {
+        String projectGoal = mavenProject.getDefaultGoal()
+        String projectId = mavenProject.getId()
+        ExecutionEvent projectStopEvent = aMojoEvent(ExecutionEvent.Type.ProjectSucceeded,
+                                                     projectGoal, projectId,
+                                                     mavenProject)
+        profiler.onEvent(projectStopEvent)
+    }
+
+    private static void simulateMojoExecutedSuccessfully(ProfilerEventSpy profiler,
+                                                         MavenProject mavenProject,
+                                                         String goal, String id) {
+        Plugin plugin = new Plugin()
+        MojoExecution mojo = new MojoExecution(plugin, goal, id)
+
+        ExecutionEvent startEvent = aMojoStartEvent(mojo, mavenProject)
+        profiler.onEvent(startEvent)
+
+        MILLISECONDS.sleep(random.nextInt() % 10)
+
+        ExecutionEvent stopEvent = aMojoStopEvent(mojo, mavenProject)
+        profiler.onEvent(stopEvent)
+    }
+
+    private static ExecutionEvent aMojoStartedEvent(ExecutionEvent.Type type, MavenProject mavenProject) {
+        aMojoEvent(type, new MojoExecution(new Plugin(), 'goal', 'execution.id'), mavenProject)
+    }
+
+    private static ExecutionEvent aMojoStartEvent(MojoExecution mojoExecution, MavenProject mavenProject) {
+        aMojoEvent(ExecutionEvent.Type.MojoStarted, mojoExecution, mavenProject)
+    }
+
+    private static ExecutionEvent aMojoStopEvent(MojoExecution mojoExecution, MavenProject mavenProject) {
+        aMojoEvent(ExecutionEvent.Type.MojoSucceeded, mojoExecution, mavenProject)
+    }
+
+    private static ExecutionEvent aMojoEvent(ExecutionEvent.Type type,
+                                             MojoExecution mojoExecution,
+                                             MavenProject mavenProject) {
+        new TestExecutionEvent(type, mojoExecution, mavenProject)
+    }
+
+    private static ExecutionEvent aMojoEvent(ExecutionEvent.Type type,
+                                             String goal, String id,
+                                             MavenProject mavenProject) {
+        new TestExecutionEvent(type, new MojoExecution(new Plugin(), goal, id), mavenProject)
+    }
+}
+


### PR DESCRIPTION
With the new feature, the user can add the flag `-DdisableTimeSorting` and the profiler won't sort the execution times in the final report.

Also some small improvements in a couple of condition evaluations (added missing `else`s statements to avoid unnecessary condition evaluations, replaced a couple of `if` statements with a `switch` expression) 