### PR TITLE
Document naming experiments and add profile name to reports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
 install:
   - ./mvnw install -Dinvoker.skip=true -DskipTests=true -B -V
 script:
-  - ./mvnw package sonar:sonar -Prun-coverage -B
+  - ./mvnw package -Prun-coverage -B
 after_success:
   - "[[ ${TRAVIS_PULL_REQUEST} == 'false' ]] && [[ ${TRAVIS_TAG} == '' ]] && ./mvnw deploy -Dinvoker.skip=true -DskipTests --settings etc/deploy-settings.xml"
   - ./mvnw verify coveralls:report -Dinvoker.skip=true -Prun-coverage

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ or you can define it using a system property:
 ```
 {
   "name": "maven-profiler",
+  "profile_name": "",
   "time": "44681 ms",
   "goals": "clean install",
   "date": "2017/01/21 19:10:04",

--- a/README.md
+++ b/README.md
@@ -54,8 +54,16 @@ Use property `profile` when running Maven.
 
 	mvn install -Dprofile
 
-This will generate a report in `.profiler` folder.  
-This also works when `mvn` is executed on multiple threads (option `-T`).
+This will generate a report in `.profiler` folder.
+
+You might also add a profile name, which is included in the [report](#report-format)
+and helps identify the experiment:
+    
+    mvn clean install -Dprofile="No custom JVM options"
+    export MAVEN_OPTS='-XX:TieredStopAtLevel=1 -XX:+UseParallelGC'
+    mvn clean install -Dprofile="With custom JVM options=${MAVEN_OPTS}"
+
+The extension also works when `mvn` is executed on multiple threads (option `-T`).
 
 ### Report format
 

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy</artifactId>
-            <version>2.4.16</version>
+            <version>2.5.7</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -143,6 +143,7 @@
             <plugin>
                 <groupId>org.codehaus.gmavenplus</groupId>
                 <artifactId>gmavenplus-plugin</artifactId>
+                <version>1.7.1</version>
                 <executions>
                     <execution>
                         <goals>

--- a/src/main/java/fr/jcgay/maven/profiler/Configuration.java
+++ b/src/main/java/fr/jcgay/maven/profiler/Configuration.java
@@ -14,6 +14,7 @@ import java.util.List;
 
 import static com.google.common.base.Functions.compose;
 import static com.google.common.base.Functions.forMap;
+import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Collections2.transform;
 import static java.util.Arrays.asList;
 
@@ -29,21 +30,29 @@ public class Configuration {
     		.build()), String::toLowerCase);
 
     private final boolean isProfiling;
+    private final String profileName;
     private final Reporter reporter;
     private final Sorter sorter;
 
-    public Configuration(boolean isProfiling, Reporter reporter, Sorter sorter) {
+    public Configuration(boolean isProfiling, String profileName, Reporter reporter,
+        Sorter sorter) {
         this.isProfiling = isProfiling;
+        this.profileName = checkNotNull(profileName);
         this.reporter = reporter;
         this.sorter = sorter;
     }
 
     public static Configuration read() {
-        return new Configuration(isActive(), chooseReporter(), chooseSorter());
+        return new Configuration(isActive(), getProfileName(), chooseReporter(), chooseSorter());
     }
 
     public boolean isProfiling() {
         return isProfiling;
+    }
+
+    /** Returns the profile name. Never {@code null}, may be empty if not provided. */
+    public String profileName() {
+        return profileName;
     }
 
     public Reporter reporter() {
@@ -69,6 +78,10 @@ public class Configuration {
     private static boolean isSortingActive() {
         String parameter = System.getProperty(DISABLE_TIME_SORTING);
         return parameter == null || "false".equalsIgnoreCase(parameter);
+    }
+
+    private static String getProfileName() {
+        return System.getProperty(PROFILE, "");
     }
 
     private static boolean isActive() {

--- a/src/main/java/fr/jcgay/maven/profiler/Configuration.java
+++ b/src/main/java/fr/jcgay/maven/profiler/Configuration.java
@@ -81,7 +81,12 @@ public class Configuration {
     }
 
     private static String getProfileName() {
-        return System.getProperty(PROFILE, "");
+        String profile = System.getProperty(PROFILE, "");
+        if (profile.equals("true")) {
+            // Use empty name if the property is specified as `-Dprofile`
+            return "";
+        }
+        return profile;
     }
 
     private static boolean isActive() {

--- a/src/main/java/fr/jcgay/maven/profiler/ProfilerEventSpy.java
+++ b/src/main/java/fr/jcgay/maven/profiler/ProfilerEventSpy.java
@@ -100,7 +100,8 @@ public class ProfilerEventSpy extends AbstractEventSpy {
             Data context = new Data()
                 .setProjects(sortedProjects())
                 .setDate(finishTime)
-                .setName(statistics.topProject().getName())
+                .setTopProjectName(statistics.topProject().getName())
+                .setProfileName(configuration.profileName())
                 .setGoals(Joiner.on(' ').join(statistics.goals()))
                 .setParameters(statistics.properties());
             setDownloads(context);

--- a/src/main/java/fr/jcgay/maven/profiler/reporting/json/JsonReporter.java
+++ b/src/main/java/fr/jcgay/maven/profiler/reporting/json/JsonReporter.java
@@ -31,7 +31,8 @@ public class JsonReporter implements Reporter {
 
     private String getJSONRepresentation(Data context) {
         JsonObject obj = new JsonObject();
-        obj.add("name", context.getName());
+        obj.add("name", context.getTopProjectName());
+        obj.add("profile_name", context.getProfileName());
         obj.add("time", ms(context.getBuildTime()));
         obj.add("goals", context.getGoals());
         obj.add("date", context.getFormattedDate());

--- a/src/main/java/fr/jcgay/maven/profiler/reporting/template/Data.java
+++ b/src/main/java/fr/jcgay/maven/profiler/reporting/template/Data.java
@@ -18,7 +18,8 @@ public class Data {
     private Stopwatch totalDownloadTime;
     private Stopwatch buildTime;
     private Date date;
-    private String name;
+    private String topProjectName;
+    private String profileName;
     private String goals;
     private Properties parameters;
 
@@ -50,8 +51,12 @@ public class Data {
         return new SimpleDateFormat("yyyy/MM/dd HH:mm:ss").format(date);
     }
 
-    public String getName() {
-        return name;
+    public String getTopProjectName() {
+        return topProjectName;
+    }
+
+    public String getProfileName() {
+        return profileName;
     }
 
     public String getGoals() {
@@ -87,8 +92,13 @@ public class Data {
         return this;
     }
 
-    public Data setName(String name) {
-        this.name = name;
+    public Data setTopProjectName(String name) {
+        this.topProjectName = name;
+        return this;
+    }
+
+    public Data setProfileName(String profileName) {
+        this.profileName = profileName;
         return this;
     }
 

--- a/src/main/resources/report-template.hbs
+++ b/src/main/resources/report-template.hbs
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>Maven Profiler report</title>
+    <title>Maven Profiler Report {{profileName}}</title>
     <style>
         body {
             padding: 30px 50px;
@@ -53,7 +53,7 @@
 </head>
 <body>
     <section>
-        <h1>{{name}} ({{buildTime}})</h1>
+        <h1>{{topProjectName}} ({{buildTime}})</h1>
         <p>Run <b>{{goals}}</b> on {{formattedDate}} with parameters: {{parameters}}</p>
 
         {{#projects}}

--- a/src/test/groovy/fr/jcgay/maven/profiler/ConfigurationTest.groovy
+++ b/src/test/groovy/fr/jcgay/maven/profiler/ConfigurationTest.groovy
@@ -1,5 +1,6 @@
 package fr.jcgay.maven.profiler
 
+import com.google.common.collect.ImmutableList
 import fr.jcgay.maven.profiler.reporting.html.HtmlReporter
 import fr.jcgay.maven.profiler.reporting.json.JsonReporter
 import fr.jcgay.maven.profiler.sorting.execution.ByExecutionOrder
@@ -19,13 +20,27 @@ class ConfigurationTest {
         System.clearProperty('disableTimeSorting')
     }
 
-    @Test
-    void 'indicate that profiling is active'() {
-        System.setProperty('profile', 'true')
+    @DataProvider
+    Object[][] 'valid profile properties'() {
+        [[""], ["true"], ["Profile Name"]]
+    }
+
+    @Test(dataProvider = 'valid profile properties')
+    void 'indicate that profiling is active'(String profileValue) {
+        System.setProperty('profile', profileValue)
 
         def result = Configuration.read()
 
         assertThat(result.isProfiling()).isTrue()
+    }
+
+    @Test(dataProvider = 'valid profile properties')
+    void 'keeps profile name'(String profileValue) {
+        System.setProperty('profile', profileValue)
+
+        def result = Configuration.read()
+
+        assertThat(result.profileName()).isEqualTo(profileValue);
     }
 
     @DataProvider
@@ -84,6 +99,7 @@ class ConfigurationTest {
         def result = Configuration.read()
 
         assertThat(result.isProfiling()).isFalse()
+        assertThat(result.profileName()).isEmpty();
         assertThat(result.reporter().delegates).extracting("class").containsExactly(HtmlReporter)
         assertThat(result.sorter()).isExactlyInstanceOf(ByExecutionTime)
     }

--- a/src/test/groovy/fr/jcgay/maven/profiler/ConfigurationTest.groovy
+++ b/src/test/groovy/fr/jcgay/maven/profiler/ConfigurationTest.groovy
@@ -1,6 +1,6 @@
 package fr.jcgay.maven.profiler
 
-import com.google.common.collect.ImmutableList
+
 import fr.jcgay.maven.profiler.reporting.html.HtmlReporter
 import fr.jcgay.maven.profiler.reporting.json.JsonReporter
 import fr.jcgay.maven.profiler.sorting.execution.ByExecutionOrder
@@ -21,11 +21,11 @@ class ConfigurationTest {
     }
 
     @DataProvider
-    Object[][] 'valid profile properties'() {
+    Object[][] 'active profile properties'() {
         [[""], ["true"], ["Profile Name"]]
     }
 
-    @Test(dataProvider = 'valid profile properties')
+    @Test(dataProvider = 'active profile properties')
     void 'indicate that profiling is active'(String profileValue) {
         System.setProperty('profile', profileValue)
 
@@ -34,13 +34,18 @@ class ConfigurationTest {
         assertThat(result.isProfiling()).isTrue()
     }
 
-    @Test(dataProvider = 'valid profile properties')
-    void 'keeps profile name'(String profileValue) {
+    @DataProvider
+    Object[][] 'profile names'() {
+        [["", ""], ["true", ""], ["Profile Name", "Profile Name"]]
+    }
+
+    @Test(dataProvider = 'profile names')
+    void 'keeps profile name'(String profileValue, String expectedName) {
         System.setProperty('profile', profileValue)
 
         def result = Configuration.read()
 
-        assertThat(result.profileName()).isEqualTo(profileValue);
+        assertThat(result.profileName()).isEqualTo(expectedName)
     }
 
     @DataProvider
@@ -99,7 +104,7 @@ class ConfigurationTest {
         def result = Configuration.read()
 
         assertThat(result.isProfiling()).isFalse()
-        assertThat(result.profileName()).isEmpty();
+        assertThat(result.profileName()).isEmpty()
         assertThat(result.reporter().delegates).extracting("class").containsExactly(HtmlReporter)
         assertThat(result.sorter()).isExactlyInstanceOf(ByExecutionTime)
     }

--- a/src/test/groovy/fr/jcgay/maven/profiler/NoProfilingTest.groovy
+++ b/src/test/groovy/fr/jcgay/maven/profiler/NoProfilingTest.groovy
@@ -25,7 +25,7 @@ class NoProfilingTest {
         RepositoryEvent endDownloadEvent = aRepositoryEvent(ARTIFACT_DOWNLOADED, anArtifact()).build()
 
         def statistics = new Statistics()
-        ProfilerEventSpy profiler = new ProfilerEventSpy(statistics, new Configuration(false, mock(Reporter), mock(Sorter)), { new Date() })
+        ProfilerEventSpy profiler = new ProfilerEventSpy(statistics, new Configuration(false, "", mock(Reporter), mock(Sorter)), { new Date() })
 
         // When
         profiler.onEvent(startEvent)

--- a/src/test/groovy/fr/jcgay/maven/profiler/ProfilerEventSpyTest.groovy
+++ b/src/test/groovy/fr/jcgay/maven/profiler/ProfilerEventSpyTest.groovy
@@ -46,7 +46,8 @@ class ProfilerEventSpyTest {
         statistics = new Statistics()
             .setTopProject(topProject)
 
-        profiler = new ProfilerEventSpy(statistics, new Configuration(true, reporter, sorter), { finishTime })
+        def profileName = "P1"
+        profiler = new ProfilerEventSpy(statistics, new Configuration(true, profileName, reporter, sorter), { finishTime })
     }
 
     @Test

--- a/src/test/groovy/fr/jcgay/maven/profiler/ReportsWithSortingDisabledTest.groovy
+++ b/src/test/groovy/fr/jcgay/maven/profiler/ReportsWithSortingDisabledTest.groovy
@@ -35,7 +35,8 @@ class ReportsWithSortingDisabledTest {
         statistics = new Statistics()
             .setTopProject(aMavenTopProject('top-project'))
 
-        profiler = new ProfilerEventSpy(statistics, new Configuration(true, reporter, new ByExecutionOrder()), { new Date() })
+        def profileName = 'P1'
+        profiler = new ProfilerEventSpy(statistics, new Configuration(true, profileName, reporter, new ByExecutionOrder()), { new Date() })
     }
 
     @Test


### PR DESCRIPTION
Hi, @jcgay ,

Thanks for an awesome extension, it helped a lot to get some insights into our builds. We recently run some experiments in attempts to optimize them, and
discovered that it might be hard to distinguish between the reports when reviewing several of them.

I suggest to allow specifying the experiment name right in the `profile` property. It already works as an implementation detail of the current version, I suggest to make it a feature — documented and supported.

Such treatment will also allow the profile name to be put into the report more prominently — not in a list of all properties, but as a separate paragraph or a subtitle.