### PR TITLE
Activate profiling with mvnd

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,17 @@
     </dependencies>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <configuration>
+                        <append>true</append>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.codehaus.plexus</groupId>
@@ -161,6 +172,7 @@
                     <cloneClean>true</cloneClean>
                     <showVersion>true</showVersion>
                     <postBuildHookScript>verify.groovy</postBuildHookScript>
+                    <mavenOpts>${argLine}</mavenOpts>
                 </configuration>
                 <executions>
                     <execution>

--- a/src/test/groovy/fr/jcgay/maven/profiler/NoProfilingTest.groovy
+++ b/src/test/groovy/fr/jcgay/maven/profiler/NoProfilingTest.groovy
@@ -2,6 +2,7 @@ package fr.jcgay.maven.profiler
 
 import fr.jcgay.maven.profiler.reporting.Reporter
 import fr.jcgay.maven.profiler.sorting.Sorter
+import groovy.transform.CompileStatic
 import org.apache.maven.execution.ExecutionEvent
 import org.assertj.guava.api.Assertions
 import org.eclipse.aether.RepositoryEvent
@@ -14,6 +15,7 @@ import static org.eclipse.aether.RepositoryEvent.EventType.ARTIFACT_DOWNLOADED
 import static org.eclipse.aether.RepositoryEvent.EventType.ARTIFACT_DOWNLOADING
 import static org.mockito.Mockito.mock
 
+@CompileStatic
 class NoProfilingTest {
 
     @Test
@@ -25,7 +27,8 @@ class NoProfilingTest {
         RepositoryEvent endDownloadEvent = aRepositoryEvent(ARTIFACT_DOWNLOADED, anArtifact()).build()
 
         def statistics = new Statistics()
-        ProfilerEventSpy profiler = new ProfilerEventSpy(statistics, new Configuration(false, "", mock(Reporter), mock(Sorter)), { new Date() })
+        ProfilerEventSpy profiler = new ProfilerEventSpy(() -> statistics, () -> new Configuration(false, "", mock(Reporter), mock(Sorter)), { new Date() })
+        profiler.init(null)
 
         // When
         profiler.onEvent(startEvent)

--- a/src/test/groovy/fr/jcgay/maven/profiler/ProfilerEventSpyTest.groovy
+++ b/src/test/groovy/fr/jcgay/maven/profiler/ProfilerEventSpyTest.groovy
@@ -47,7 +47,8 @@ class ProfilerEventSpyTest {
             .setTopProject(topProject)
 
         def profileName = "P1"
-        profiler = new ProfilerEventSpy(statistics, new Configuration(true, profileName, reporter, sorter), { finishTime })
+        profiler = new ProfilerEventSpy(() -> statistics, () -> new Configuration(true, profileName, reporter, sorter), { finishTime })
+        profiler.init(null)
     }
 
     @Test

--- a/src/test/groovy/fr/jcgay/maven/profiler/ReportsWithSortingDisabledTest.groovy
+++ b/src/test/groovy/fr/jcgay/maven/profiler/ReportsWithSortingDisabledTest.groovy
@@ -36,7 +36,8 @@ class ReportsWithSortingDisabledTest {
             .setTopProject(aMavenTopProject('top-project'))
 
         def profileName = 'P1'
-        profiler = new ProfilerEventSpy(statistics, new Configuration(true, profileName, reporter, new ByExecutionOrder()), { new Date() })
+        profiler = new ProfilerEventSpy(() -> statistics, () -> new Configuration(true, profileName, reporter, new ByExecutionOrder()), { new Date() })
+        profiler.init(null)
     }
 
     @Test


### PR DESCRIPTION
Fixes #109

When the mvnd daemon is instantiating the EventSpy the configuration do not
have access to system properties passed by the CLI.

Instead of initializing state in ProfilerEventSpy constructor, everything is now
done in the init method.