### PR TITLE
Hide user parameters in report

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ or you can define it using a system property:
 
     mvn install -Dprofile -Dmaven-profiler-report-directory=/tmp/profiler-custom-report
 
+### Hide parameters in reports
+
+User parameters could leak sensitive data, you can disable reporting them using:
+
+    mvn install -Dprofile -DhideParameters=true
+
 ## Output examples
 
 ### HTML

--- a/src/main/java/fr/jcgay/maven/profiler/Configuration.java
+++ b/src/main/java/fr/jcgay/maven/profiler/Configuration.java
@@ -23,6 +23,7 @@ public class Configuration {
     private static final String PROFILE = "profile";
     private static final String PROFILE_FORMAT = "profileFormat";
     private static final String DISABLE_TIME_SORTING = "disableTimeSorting";
+    private static final String DISABLE_PARAMETERS_REPORT = "hideParameters";
 
     private static final Function<String,Reporter> reporters =  compose(forMap(ImmutableMap.<String,Reporter>builder()
     		.put("html", new HtmlReporter())
@@ -33,17 +34,18 @@ public class Configuration {
     private final String profileName;
     private final Reporter reporter;
     private final Sorter sorter;
+    private final boolean shouldPrintParameters;
 
-    public Configuration(boolean isProfiling, String profileName, Reporter reporter,
-        Sorter sorter) {
+    public Configuration(boolean isProfiling, String profileName, Reporter reporter, Sorter sorter, boolean shouldPrintParameters) {
         this.isProfiling = isProfiling;
         this.profileName = checkNotNull(profileName);
         this.reporter = reporter;
         this.sorter = sorter;
+        this.shouldPrintParameters = shouldPrintParameters;
     }
 
     public static Configuration read() {
-        return new Configuration(isActive(), getProfileName(), chooseReporter(), chooseSorter());
+        return new Configuration(isActive(), getProfileName(), chooseReporter(), chooseSorter(), hasParametersReportEnabled());
     }
 
     public boolean isProfiling() {
@@ -61,6 +63,14 @@ public class Configuration {
 
     public Sorter sorter() {
         return sorter;
+    }
+
+    public boolean shouldPrintParameters() {
+        return shouldPrintParameters;
+    }
+
+    private static boolean hasParametersReportEnabled() {
+        return Boolean.parseBoolean(System.getProperty(DISABLE_PARAMETERS_REPORT, "false"));
     }
 
     private static Sorter chooseSorter() {

--- a/src/main/java/fr/jcgay/maven/profiler/ProfilerEventSpy.java
+++ b/src/main/java/fr/jcgay/maven/profiler/ProfilerEventSpy.java
@@ -82,7 +82,9 @@ public class ProfilerEventSpy extends AbstractEventSpy {
             if (event instanceof DefaultMavenExecutionRequest) {
                 DefaultMavenExecutionRequest mavenEvent = (DefaultMavenExecutionRequest) event;
                 statistics.setGoals(new LinkedHashSet<>(mavenEvent.getGoals()));
-                statistics.setProperties(mavenEvent.getUserProperties());
+                if (configuration.shouldPrintParameters()) {
+                    statistics.setProperties(mavenEvent.getUserProperties());
+                }
             } else if (event instanceof ExecutionEvent) {
                 storeExecutionEvent((ExecutionEvent) event);
                 trySaveTopProject((ExecutionEvent) event);

--- a/src/test/groovy/fr/jcgay/maven/profiler/NoProfilingTest.groovy
+++ b/src/test/groovy/fr/jcgay/maven/profiler/NoProfilingTest.groovy
@@ -3,6 +3,7 @@ package fr.jcgay.maven.profiler
 import fr.jcgay.maven.profiler.reporting.Reporter
 import fr.jcgay.maven.profiler.sorting.Sorter
 import groovy.transform.CompileStatic
+import org.apache.maven.execution.DefaultMavenExecutionRequest
 import org.apache.maven.execution.ExecutionEvent
 import org.assertj.guava.api.Assertions
 import org.eclipse.aether.RepositoryEvent
@@ -11,6 +12,7 @@ import org.testng.annotations.Test
 import static fr.jcgay.maven.profiler.MavenStubs.*
 import static org.apache.maven.execution.ExecutionEvent.Type.MojoSucceeded
 import static org.assertj.core.api.Assertions.assertThat
+import static org.assertj.core.api.Assertions.entry
 import static org.eclipse.aether.RepositoryEvent.EventType.ARTIFACT_DOWNLOADED
 import static org.eclipse.aether.RepositoryEvent.EventType.ARTIFACT_DOWNLOADING
 import static org.mockito.Mockito.mock
@@ -27,7 +29,7 @@ class NoProfilingTest {
         RepositoryEvent endDownloadEvent = aRepositoryEvent(ARTIFACT_DOWNLOADED, anArtifact()).build()
 
         def statistics = new Statistics()
-        ProfilerEventSpy profiler = new ProfilerEventSpy(() -> statistics, () -> new Configuration(false, "", mock(Reporter), mock(Sorter)), { new Date() })
+        ProfilerEventSpy profiler = new ProfilerEventSpy(() -> statistics, () -> new Configuration(false, "", mock(Reporter), mock(Sorter), true), { new Date() })
         profiler.init(null)
 
         // When
@@ -40,5 +42,40 @@ class NoProfilingTest {
         assertThat(statistics.projects()).isEmpty()
         assertThat(statistics.downloads()).isEmpty()
         Assertions.assertThat(statistics.executions()).isEmpty()
+    }
+
+    @Test
+    void 'should not report parameters when configuration is disable'() {
+        def statistics = new Statistics()
+        statistics.setTopProject(aMavenTopProject("project-hiding-properties"))
+        ProfilerEventSpy profiler = new ProfilerEventSpy(() -> statistics, () -> new Configuration(true, "", mock(Reporter), mock(Sorter), false), { new Date() })
+        def event = new DefaultMavenExecutionRequest()
+        def properties = new Properties()
+        properties.put("should-not-be-reported", "Hide me please!")
+        event.setUserProperties(properties)
+
+        profiler.init(null)
+        profiler.onEvent(event)
+        profiler.close()
+
+        assertThat(statistics.properties()).isEmpty()
+    }
+
+    @Test
+    void 'should report parameters when configuration is enable'() {
+        def statistics = new Statistics()
+        statistics.setTopProject(aMavenTopProject("project-reporting-properties"))
+        ProfilerEventSpy profiler = new ProfilerEventSpy(() -> statistics, () -> new Configuration(true, "", mock(Reporter), mock(Sorter), true), { new Date() })
+        def event = new DefaultMavenExecutionRequest()
+        def properties = new Properties()
+        properties.put("should-be-reported", "Print me please!")
+        event.setUserProperties(properties)
+
+        profiler.init(null)
+        profiler.onEvent(event)
+        profiler.close()
+
+        assertThat(statistics.properties())
+            .containsExactly(entry("should-be-reported", "Print me please!"))
     }
 }

--- a/src/test/groovy/fr/jcgay/maven/profiler/ProfilerEventSpyTest.groovy
+++ b/src/test/groovy/fr/jcgay/maven/profiler/ProfilerEventSpyTest.groovy
@@ -47,7 +47,7 @@ class ProfilerEventSpyTest {
             .setTopProject(topProject)
 
         def profileName = "P1"
-        profiler = new ProfilerEventSpy(() -> statistics, () -> new Configuration(true, profileName, reporter, sorter), { finishTime })
+        profiler = new ProfilerEventSpy(() -> statistics, () -> new Configuration(true, profileName, reporter, sorter, true), { finishTime })
         profiler.init(null)
     }
 

--- a/src/test/groovy/fr/jcgay/maven/profiler/ReportsWithSortingDisabledTest.groovy
+++ b/src/test/groovy/fr/jcgay/maven/profiler/ReportsWithSortingDisabledTest.groovy
@@ -36,7 +36,7 @@ class ReportsWithSortingDisabledTest {
             .setTopProject(aMavenTopProject('top-project'))
 
         def profileName = 'P1'
-        profiler = new ProfilerEventSpy(() -> statistics, () -> new Configuration(true, profileName, reporter, new ByExecutionOrder()), { new Date() })
+        profiler = new ProfilerEventSpy(() -> statistics, () -> new Configuration(true, profileName, reporter, new ByExecutionOrder(), true), { new Date() })
         profiler.init(null)
     }
 


### PR DESCRIPTION
User parameters could leak sensitive data, you can disable reporting them using:

    mvn install -Dprofile -DhideParameters=true

Resolves #11