### PR TITLE
Prevent NPE when extension is initiated after another one

### DIFF
--- a/src/main/java/fr/jcgay/maven/profiler/ProfilerEventSpy.java
+++ b/src/main/java/fr/jcgay/maven/profiler/ProfilerEventSpy.java
@@ -51,7 +51,9 @@ public class ProfilerEventSpy extends AbstractEventSpy {
 
     public ProfilerEventSpy() {
         this.statisticsSupplier = Statistics::new;
+        this.statistics = statisticsSupplier.get();
         this.configurationSupplier = Configuration::read;
+        this.configuration = configurationSupplier.get();
         this.now = Date::new;
     }
 


### PR DESCRIPTION
When maven-profiler is installed in the Maven distribution ext folder
and a project uses other extension from the .mvn/extensions.xml configuration,
maven-profiler was failing with NPE in fr.jcgay.maven.profiler.ProfilerEventSpy#onEvent.

This is because the #init method of the extension was not yet called when Maven was loading
extension from .mvn/extensions.xml. Maven was firing event intercepted by maven-profiler
but as it was not yet initiated, the configuration and statistics internal state was not ready.

This commit also initiate its state in the constructor.
It will prevent NPE but the statistics gathered between the instantiation and the initialization
will be lost anyway 😥. Because #init will clean internal state, and we need this to have the extension
functional with mvnd.

Fixes #199
